### PR TITLE
Add automatic download of verification csv to RP report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 AWS_PROFILE=verify-audit-billing-dev
 RP_REPORT_OUTPUT_BUCKET=govukverify-hub-integration-billing-reports
+BILLING_REPORT_S3_BUCKET=verifications-bucket-name

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Scripts for running the RP report
     brew install pre-commit
     ```
 
+1. An AWS account with credentials configured in `~/.aws/credentials`, with permissions to access the billing pre-prod account
+
 ### Installation
 From the project root directory, run the following in terminal:
 ```
@@ -30,6 +32,15 @@ make requirements-dev
     
 This will create a Python virtual environment (sometimes referred to as Virtualenv or venv) and install all the required dependencies into it.
     
+## Configure environment variables
+Environment variables required to run the reports are set in the file .env. 
+
+Make a copy of the sample file, 
+```
+cp .env.sample .env
+```
+Then open the file `.env` and fill in the values 
+
 ## Using the Python Virtual Environment 
 We are using an isolated Python environment to allow modules, dependencies, etc. used by this project to not affect another. 
 

--- a/performance/billing.py
+++ b/performance/billing.py
@@ -1,10 +1,13 @@
 import argparse
+import os
 from datetime import timedelta, datetime
 
 import pandas
 
 from performance import config
 from performance.rp_federation_config import rp_mapping
+from performance.billing_report_s3_downloader import BillingReportS3Downloader
+from performance import aws
 
 
 def fromisoformat(date_string):
@@ -15,18 +18,29 @@ def fromisoformat(date_string):
         raise argparse.ArgumentTypeError(msg)
 
 
-def extract_verifications_by_rp_csv_for_date(date_start):
+def extract_verifications_by_rp_csv_for_week(date_start):
     """
     Extract billing data from the weekly verifications_by_rp.csv report
     :param date_start: start date for the week
     :return: pandas.Dataframe with non transformed data with matching columns to the original verifications_by_rp
     """
-    date_end = fromisoformat(date_start) + timedelta(days=6)
+    verifications_by_rp_csv_filename = get_verification_report_filename_for_week(date_start)
+    verifications_by_rp_csv_folder = f'{config.VERIFY_DATA_PIPELINE_CONFIG_PATH}/data/verifications'
+
     verifications_by_rp_csv_path = \
-        f'{config.VERIFY_DATA_PIPELINE_CONFIG_PATH}/data/verifications/verifications_by_rp_{date_start}_{date_end}.csv'
+        f'{verifications_by_rp_csv_folder}/{verifications_by_rp_csv_filename}'
+
+    if not os.path.exists(verifications_by_rp_csv_path):
+        download_verifications_by_rp_report_for_week(date_start)
 
     df_verifications_by_rp = pandas.read_csv(verifications_by_rp_csv_path)
     return df_verifications_by_rp
+
+
+def get_verification_report_filename_for_week(date_start):
+    date_end = fromisoformat(date_start) + timedelta(days=6)
+    verifications_by_rp_csv_filename = f'verifications_by_rp_{date_start}_{date_end}.csv'
+    return verifications_by_rp_csv_filename
 
 
 def augment_verifications_by_rp_with_rp_name(df_verifications_by_rp):
@@ -37,3 +51,12 @@ def augment_verifications_by_rp_with_rp_name(df_verifications_by_rp):
     """
     df_verifications_by_rp['rp'] = df_verifications_by_rp.apply(lambda row: rp_mapping[row['RP Entity Id']],
                                                                 axis=1)
+
+
+def download_verifications_by_rp_report_for_week(date_start):
+    verifications_by_rp_csv_filename = get_verification_report_filename_for_week(date_start)
+    verifications_by_rp_csv_local_folder = f'{config.VERIFY_DATA_PIPELINE_CONFIG_PATH}/data/verifications'
+
+    billing_report_downloader = BillingReportS3Downloader(aws.get_s3_resource())
+    billing_report_downloader.download_verifications_by_rp_report_to_folder(
+        verifications_by_rp_csv_filename, verifications_by_rp_csv_local_folder)

--- a/performance/billing_report_s3_downloader.py
+++ b/performance/billing_report_s3_downloader.py
@@ -1,0 +1,26 @@
+from performance.env import check_get_env
+
+
+class BillingReportS3Downloader:
+
+    VERIFICATIONS_BY_RP_S3_FOLDER = 'rp'
+
+    def __init__(self, resource):
+        """
+        Args:
+            resource: AWS S3 resource object.
+        """
+        self._resource = resource
+        self.verifications_by_rp_s3_bucket = check_get_env('BILLING_REPORT_S3_BUCKET')
+
+    def download_verifications_by_rp_report_to_folder(self, filename, destination_folder):
+        print(f'Downloading verifications_by_RP_report {filename} from AWS S3')
+        self.download(
+            self.verifications_by_rp_s3_bucket,
+            self.VERIFICATIONS_BY_RP_S3_FOLDER,
+            filename,
+            destination_folder)
+
+    def download(self, bucket_name, bucket_folder_path, file_name, destination_folder):
+        bucket = self._resource.Bucket(bucket_name)
+        bucket.download_file(f'{bucket_folder_path}/{file_name}', f'{destination_folder}/{file_name}')

--- a/performance/reports/rp.py
+++ b/performance/reports/rp.py
@@ -58,7 +58,7 @@ def export_metrics_to_csv(df_export, report_output_path, date_start):
 
 def generate_weekly_report_for_date(date_start, report_output_path):
     # load billing csv file
-    df_verifications_by_rp = billing.extract_verifications_by_rp_csv_for_date(date_start)
+    df_verifications_by_rp = billing.extract_verifications_by_rp_csv_for_week(date_start)
     billing.augment_verifications_by_rp_with_rp_name(df_verifications_by_rp)
     df_all = generate_weekly_report_df(date_start, df_verifications_by_rp)
     # Re-order columns and choose the ones we actually (currently) want in our report

--- a/performance/tests/test_billing.py
+++ b/performance/tests/test_billing.py
@@ -7,17 +7,48 @@ import performance.billing as billing
 from performance.tests.fixtures import get_sample_verifications_by_rp_dataframe, get_sample_rp_mapping
 
 
-@patch('pandas.read_csv')
+@patch('os.path.exists', return_value=True)
 @patch('performance.billing.config', VERIFY_DATA_PIPELINE_CONFIG_PATH='my_path')
-def test_extract_verifications_by_rp_csv_for_date(mock_config, mock_pandas_read_csv):
+@patch('performance.billing.BillingReportS3Downloader')
+@patch('pandas.read_csv')
+def test_extract_verifications_by_rp_csv_for_week(mock_pandas_read_csv, mock_billing_report_downloader, mock_config, _):
     date_start = '2018-07-02'
     expected_verification_csv_filepath_to_load = os.path.join(
         'my_path',
         'data/verifications/verifications_by_rp_2018-07-02_2018-07-08.csv')
 
-    billing.extract_verifications_by_rp_csv_for_date(date_start)
+    billing.extract_verifications_by_rp_csv_for_week(date_start)
 
     mock_pandas_read_csv.assert_called_with(expected_verification_csv_filepath_to_load)
+    mock_billing_report_downloader.download_verifications_by_rp_report_to_folder.assert_not_called()
+
+
+@patch("os.path.exists", return_value=False)
+@patch('performance.billing.config', VERIFY_DATA_PIPELINE_CONFIG_PATH='my_path')
+@patch('performance.billing.BillingReportS3Downloader')
+@patch('pandas.read_csv')
+def test_extract_verifications_by_rp_downloads_csv_when_not_present(mock_pandas_read_csv,
+                                                                    mock_billing_report_downloader, mock_config, _):
+    date_start = '2018-07-02'
+    expected_verification_csv_filename = 'verifications_by_rp_2018-07-02_2018-07-08.csv'
+    expected_verification_csv_destination_path = os.path.join('my_path', 'data/verifications')
+
+    billing.extract_verifications_by_rp_csv_for_week(date_start)
+
+    mock_billing_report_downloader.return_value.download_verifications_by_rp_report_to_folder.\
+        assert_called_with(expected_verification_csv_filename, expected_verification_csv_destination_path)
+
+
+@patch('performance.billing.config', VERIFY_DATA_PIPELINE_CONFIG_PATH='pipeline_config_path', )
+@patch('performance.billing.BillingReportS3Downloader')
+def test_download_verifications_by_rp_report_for_week(mock_billing_report_downloader, mock_config):
+    start_date = '2018-09-03'
+    expected_verifications_report_filename = 'verifications_by_rp_2018-09-03_2018-09-09.csv'
+
+    billing.download_verifications_by_rp_report_for_week(start_date)
+
+    mock_billing_report_downloader.return_value.download_verifications_by_rp_report_to_folder\
+        .assert_called_with(expected_verifications_report_filename, 'pipeline_config_path/data/verifications')
 
 
 @patch('performance.billing.rp_mapping', get_sample_rp_mapping())

--- a/performance/tests/test_billing_report_s3_downloader.py
+++ b/performance/tests/test_billing_report_s3_downloader.py
@@ -1,0 +1,23 @@
+from performance.billing_report_s3_downloader import BillingReportS3Downloader
+from unittest.mock import Mock, patch
+
+
+@patch('performance.billing_report_s3_downloader.check_get_env', return_value='verifications_bucket_name')
+def test_download_verifications_by_rp_report_to_folder(mock_env):
+
+    filename = 'verifications_by_rp_2018-09-03_2018-09-09.csv'
+    destination_folder = 'destination_folder_path'
+
+    aws_resource_mock = Mock()
+    bucket = Mock()
+    aws_resource_mock.Bucket.return_value = bucket
+    billing_report_downloader = BillingReportS3Downloader(aws_resource_mock)
+
+    billing_report_downloader.download_verifications_by_rp_report_to_folder(filename, destination_folder)
+
+    expected_folder_name_in_s3 = 'rp'
+
+    aws_resource_mock.Bucket.assert_called_with('verifications_bucket_name')
+    bucket.download_file.assert_called_with(
+        f'{expected_folder_name_in_s3}/{filename}',
+        f'{destination_folder}/{filename}')


### PR DESCRIPTION
Now requires the environment variables AWS_PROFILE and
BILLING_REPORT_S3_BUCKET to be set in .env, and aws boto credentials configured.
File will only be downloaded if not already present in the file system.