### PR TITLE
PMI-753: Read Google auth credentials from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 AWS_PROFILE=verify-audit-billing-dev
 RP_REPORT_OUTPUT_BUCKET=govukverify-hub-integration-billing-reports
 PIWIK_API_TOKEN=<your-Piwik-API-token>
+GOOGLE_AUTH_PRIVATE_KEY_ID=<your-Google-auth-private-key-id>
+# GOOGLE_AUTH_PRIVATE_KEY=(cannot be set in `.env.`, must be defined in shell)
+GOOGLE_AUTH_CLIENT_EMAIL=<your-Google-auth-client-email>
+GOOGLE_AUTH_CLIENT_ID=<your-Google-auth-client-ID>
+GOOGLE_AUTH_CLIENT_CERT_URL=<your-Google-auth-client-cert-URL>

--- a/performance/config.py
+++ b/performance/config.py
@@ -22,6 +22,8 @@ class Config:
     PIWIK_LIMIT = '-1'
     PIWIK_BASE_URL = 'https://analytics-hub-prod-a-dmz.ida.digital.cabinet-office.gov.uk/index.php'
     DEFAULT_OUTPUT_PATH = os.path.join(BASE_DIR, 'output')
+    # This is only used if Google auth credentials aren't already present in environment variables See
+    # `performance.gsheets.get_pygsheets_client` for implementation details.
     GSHEETS_CREDENTIALS_FILE = os.path.join(
         VERIFY_DATA_PIPELINE_CONFIG_PATH, 'credentials', 'google_sheets_credentials.json')
 

--- a/performance/gsheets.py
+++ b/performance/gsheets.py
@@ -1,0 +1,35 @@
+import json
+import os
+import pygsheets
+import tempfile
+
+from performance.env import check_get_env
+from performance import prod_config as config
+
+
+def get_pygsheets_client():
+    google_auth_private_key_id = os.getenv('GOOGLE_AUTH_PRIVATE_KEY_ID')
+    if not google_auth_private_key_id:
+        return pygsheets.authorize(service_file=config.GSHEETS_CREDENTIALS_FILE)
+
+    creds = {
+        "type": "service_account",
+        "project_id": "verify-performance",
+        "private_key_id": google_auth_private_key_id,
+        # Private key cannot be set in `.env` at the moment and must therefore be defined in the
+        # shell when running locally.
+        "private_key": check_get_env('GOOGLE_AUTH_PRIVATE_KEY'),
+        "client_email": check_get_env('GOOGLE_AUTH_CLIENT_EMAIL'),
+        "client_id": check_get_env('GOOGLE_AUTH_CLIENT_ID'),
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": check_get_env('GOOGLE_AUTH_CLIENT_CERT_URL')
+    }
+    temp = tempfile.NamedTemporaryFile(delete=False, mode="w+t")
+    temp.write(json.dumps(creds))
+    temp.close()
+    try:
+        return pygsheets.authorize(service_file=temp.name)
+    finally:
+        os.unlink(temp.name)

--- a/performance/reports/rp.py
+++ b/performance/reports/rp.py
@@ -1,15 +1,12 @@
-import json
 import os
-import tempfile
 
 import pandas
-import pygsheets
 
+import performance
 import performance.piwik as piwik
 import performance.billing as billing
-
 from performance import prod_config as config
-import performance
+from performance.gsheets import get_pygsheets_client
 from performance.reports.tests import conftest
 
 RP_REPORT_COLUMNS = [
@@ -123,34 +120,6 @@ def export_metrics_to_google_sheets(df_export, date_start):
     pygsheets_client = get_pygsheets_client()
     exporter = GoogleSheetsRelyingPartyReportExporter(config, pygsheets_client)
     exporter.export(df_export, column_heading=date_start)
-
-
-def get_pygsheets_client():
-    google_auth_private_key_id = os.getenv('GOOGLE_AUTH_PRIVATE_KEY_ID')
-    if not google_auth_private_key_id:
-        return pygsheets.authorize(service_file=config.GSHEETS_CREDENTIALS_FILE)
-
-    creds = {
-        "type": "service_account",
-        "project_id": "verify-performance",
-        "private_key_id": os.getenv('GOOGLE_AUTH_PRIVATE_KEY_ID'),
-        # Private key cannot be set in `.env` at the moment and must therefore be defined in the
-        # shell when running locally.
-        "private_key": os.getenv('GOOGLE_AUTH_PRIVATE_KEY'),
-        "client_email": os.getenv('GOOGLE_AUTH_CLIENT_EMAIL'),
-        "client_id": os.getenv('GOOGLE_AUTH_CLIENT_ID'),
-        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-        "token_uri": "https://oauth2.googleapis.com/token",
-        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-        "client_x509_cert_url": os.getenv('GOOGLE_AUTH_CLIENT_CERT_URL')
-    }
-    temp = tempfile.NamedTemporaryFile(delete=False, mode="w+t")
-    temp.write(json.dumps(creds))
-    temp.close()
-    try:
-        return pygsheets.authorize(service_file=temp.name)
-    finally:
-        os.unlink(temp.name)
 
 
 def generate_weekly_report_for_date(date_start, report_output_path):


### PR DESCRIPTION
The implementation is quite similar to how we do this for Piwik token.

Since `Pygsheets` doesn't currently support reading credentials from an
in-memory data structure, we have had to implement creating a temporary
credentials file to do the job. We may revisit this later after the
next major release of `Pygsheets`.

Also note that, at present, `dotenv` package doesn't support multi-line
environment variables properly. Therefore, when running locally, the
environment variable `GOOGLE_AUTH_PRIVATE_KEY` cannot be defined in
`.env` file and must be defined in the shell. There is a [PR](https://github.com/theskumar/python-dotenv/pull/148) currently
open on the Github repo of `dotenv` which fixes this behaviour, so we'll
revisit this later.